### PR TITLE
Merge for latest execution version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ minishell
 .vscode/
 temp
 libamoa/libamoa.a
+heredoc_tmp

--- a/Include/executing.h
+++ b/Include/executing.h
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:44:47 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/21 15:58:45 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/22 20:44:52 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,15 +29,19 @@ typedef struct s_pipex
 
 /**
  * @brief This is the starting point of the executing part of the shell, it
- * allocates and initializes the pipex struct and starts the executing process.
+ * allocates and initializes the pipex struct, start the executing process and 
+ * calls error_management after the executing is done.
  * 
  * @param cmd The starting point of the ast
  * @param env The env struct initialized in main
  */
 void	exec_switch(t_ast *cmd, t_env *env);
 /**
- * @brief This function is called upon executing a simple command (only one
- * command, no pipes or redirects)
+ * @brief This function is called upon executing a single command. It forks the
+ * process if we are not executing an exception (cd, export or unset), then 
+ * search for redirects through search_redirects and if it has found some, calls
+ * exec_simple_redirect, else calls exec_only_child. The parent process simply 
+ * waits with waitpid.
  * 
  * @param cmd The ast base
  * @param pipex The pipex struct initialized in exec_switch
@@ -45,8 +49,9 @@ void	exec_switch(t_ast *cmd, t_env *env);
  */
 void	exec_simple(t_ast *cmd, t_pipex *pipex, t_env *env);
 /**
- * @brief This function is called upon executing a simple command that has 
- * redirects
+ * @brief This function is called upon executing a single command that has 
+ * redirects. It uses dup2 on pipex->in_fd and pipex->outfd, closes them then 
+ * calls exec_only_child just like you would without redirections.
  * 
  * @param cmd The ast base
  * @param pipex The pipex struct initialized in exec_switch
@@ -56,8 +61,9 @@ void	exec_simple_redirect(t_ast *cmd, t_pipex *pipex, t_env *env);
 /**
  * @brief This function is called upon executing a command pipeline, it is
  * recursive and will start executing the last (furthest to the right) command
- * first. It firsts uses the ft_getpath function to extract the command's path
- * and then child_execution to execute it.
+ * first. Every time it encounters a command node (Builtin or external command)
+ * it increases pipex->pipe_i to allow the correct execution, and the process 
+ * continues in child_execution.
  * 
  * @param cmd The ast base
  * @param pipex The pipex struct initialized in exec_switch
@@ -78,7 +84,12 @@ void	exec_handle_pipe(t_ast *cmd, t_pipex *pipex, t_env *env);
 void	child_execution(int cur_cmd, t_ast *cmd, t_pipex *pipex, t_env *env);
 /**
  * @brief This function executes a command if it is the last of the ast, it
- * redirects the output to stdout or a file if one has been provided in the ast.
+ * redirects the output to stdout or a file if one has been provided in the
+ * pipex struct. Then it closes every opened fd, if we are executing a builtin,
+ * we call the required function (exec_builtin), if not it uses ft_getpath to 
+ * extract the path to cmd->base->path then calls execve. If execve worked 
+ * correctly the process is replaced else, we call error_management because we
+ * did not find the command.
  * 
  * @param cur_cmd Determines the current command and the behavior adopted by the
  *  function
@@ -89,7 +100,13 @@ void	child_execution(int cur_cmd, t_ast *cmd, t_pipex *pipex, t_env *env);
 void	last_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env);
 /**
  * @brief This function executes a command if it is neither the last or the
- * first in the ast, the input and outputs follow the regular pipeline.
+ * first in the ast, the input and outputs follow the regular pipeline, except
+ * if redirections files were provided in the pipex struct.
+ * Then it closes every opened fd, if we are executing a builtin,
+ * we call the required function (exec_builtin), if not it uses ft_getpath to 
+ * extract the path to cmd->base->path then calls execve. If execve worked 
+ * correctly the process is replaced else, we call error_management because we
+ * did not find the command.
  * 
  * @param cur_cmd Determines the current command and the behavior adopted by the
  *  function
@@ -100,7 +117,12 @@ void	last_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env);
 void	middle_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env);
 /**
  * @brief This function executes a command if it is the first of the ast, it
- * redirects the input to stdin or a file if one has been provided in the ast.
+ * redirects the input to stdin or a file if one has been provided in the pipex
+  * struct. Then it closes every opened fd, if we are executing a builtin,
+ * we call the required function (exec_builtin), if not it uses ft_getpath to 
+ * extract the path to cmd->base->path then calls execve. If execve worked 
+ * correctly the process is replaced else, we call error_management because we
+ * did not find the command.
  * 
  * @param cur_cmd Determines the current command and the behavior adopted by the
  *  function
@@ -120,9 +142,10 @@ void	first_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env);
 char	*ft_getpath(char *cmd);
 /**
  * @brief This function is called at the start of the executing process, it
- * initializes every variable of the pipex_init function by default in_file and
- * out_file are "/dev/stdin" and "/dev/stdout" respectively, this can be changed
- * if there is a redirection in the ast.
+ * initializes every variable of the pipex_init function by default in_fd and
+ * out_fd are set to -1, this can be changed if there is a redirection in the
+ * ast. The pipe_fd list is only initialized if there are more than one command
+ * in the ast and when it is, only the correct number of pipes are created.
  * 
  * @param cmd The current command's ast
  * @param pipex The pipex struct initialized in exec_switch
@@ -131,7 +154,7 @@ char	*ft_getpath(char *cmd);
 void	ft_pipex_init(t_ast *cmd, t_pipex *pipex, t_env *env);
 /**
  * @brief This function is called regurarly throughout the execution process, it
- * closes both ends of every pipes in the pipex->pipe_fd
+ * closes both ends of every pipes created in the pipex->pipe_fd
  * 
  * @param cmd The current command's ast
  * @param env The env struct initialized in main
@@ -139,7 +162,7 @@ void	ft_pipex_init(t_ast *cmd, t_pipex *pipex, t_env *env);
 void	close_pipes(t_pipex *pipex, t_env *env);
 /**
  * @brief This function is called at the end of the pipeline and is used to wait
- * upon the completion of every command.
+ * upon the completion of every command with waitpid.
  * 
  * @param cmd The ast base
  * @param status The current status of executing
@@ -147,18 +170,21 @@ void	close_pipes(t_pipex *pipex, t_env *env);
 void	wait_execution(t_ast *cmd, int *status);
 /**
  * @brief This is used to create a fork using the current command's pid variable
+ * previously uninitialized.
  * 
  * @param pipex The pipex struct initialized in exec_switch
  * @param cmd The current command's ast
  */
 void	create_fork(t_pipex *pipex, t_ast *cmd);
 /**
- * @brief This function is called at the beginning and the end of the pipeline,
- * it is used to handle the redirections, if there are none, it simply redirects
- * to stdin and stdout
+ * @brief This function is called in search_redirect , it is used to handle the 
+ * redirections, if there are none, it simply returns stdin or stdout.
+ * The function will open the given file_name in read only, write only or append
+ * write only depending on the given int and if it fails it calls
+ * error_management.
  * 
- * @param file_name The redirection file name, use stdin and stdout for default
- * behaviour
+ * @param file_name The redirection file name, use /dev/stdin and /dev/stdout 
+ * for default behaviour
  * @param read_or_write 0 for read 1 for write 2 for append write
  * @param cmd The current command's ast
  * @param pipex The pipex struct initialized in exec_switch
@@ -166,13 +192,33 @@ void	create_fork(t_pipex *pipex, t_ast *cmd);
  */
 int		get_fd(char *file_name, int read_or_write, t_ast *cmd, t_pipex *pipex);
 /**
- * @brief This function is called just after ft_pipex_init and search through
- * the entire ast for redirection operaterators
+ * @brief This function is called in every child executing processes and looks
+ * recursively through every node to the right of the current one for redirects
+ * (except for heredocs, it only looks to the first node to the right) and then
+ * calls the appropraite function.
  * 
- * @param ast The ast's base
+ * @param ast The ast's current node
  * @param pipex The pipex structure
  */
 void	search_redirects(t_ast *ast, t_pipex *pipex);
+/**
+ * @brief This function is called in search_redirects if an output redirect was
+ * found, it will close any previously opened output redirection fd and open
+ * a new one with the provided file name and in append mode if necessary.
+ * 
+ * @param ast The command's node
+ * @param pipex The pipex structure
+ */
+void	redirect_output_file(t_ast *ast, t_pipex *pipex);
+/**
+ * @brief This function is called in search_redirects if an input redirect was
+ * found, it will close any previously opened input redirection fd and open
+ * a new one with the provided file name.
+ * 
+ * @param ast The command's node
+ * @param pipex The pipex structur
+ */
+void	redirect_input_file(t_ast *ast, t_pipex *pipex);
 /**
  * @brief This function is simply a switch to redirect to the correct builtin
  * function
@@ -183,7 +229,10 @@ void	search_redirects(t_ast *ast, t_pipex *pipex);
 void	exec_builtins(t_ast *cmd, t_env *env);
 /**
  * @brief This function is called upon detection of a heredoc in a command and
- * starts the process of handling it
+ * starts the process of handling it. It will open a heredoc_tmp in the working
+ * directory (supposed to change in the future), then use readline to open a 
+ * prompt for the user to type the heredoc, closes it, then reopens it in read
+ * only for the redirection to work properly down the line.
  * 
  * @param cmd The cmd's ast
  * @param pipex The pipex struct initialized in exec_switch

--- a/Include/executing.h
+++ b/Include/executing.h
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:44:47 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 19:18:12 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 15:58:45 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,6 @@
 typedef struct s_pipex
 {
 	int		pipe_i;
-	char	*in_file;
-	char	*out_file;
 	int		in_fd;
 	int		out_fd;
 	int		(*pipe_fd)[2];

--- a/Include/executing.h
+++ b/Include/executing.h
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:44:47 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/16 19:45:37 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/17 19:39:30 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -187,7 +187,8 @@ void	exec_builtins(t_ast *cmd, t_env *env);
  * starts the process of handling it
  * 
  * @param cmd The cmd's ast
+ * @param pipex The pipex struct initialized in exec_switch
  */
-void	handle_heredocs(t_ast *cmd);
+void	handle_heredocs(t_ast *cmd, t_pipex *pipex);
 
 #endif

--- a/Include/executing.h
+++ b/Include/executing.h
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:44:47 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 17:31:38 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 19:18:12 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,10 +22,11 @@ typedef struct s_pipex
 	int		pipe_i;
 	char	*in_file;
 	char	*out_file;
+	int		in_fd;
+	int		out_fd;
 	int		(*pipe_fd)[2];
 	int		status;
 	int		nb_commands;
-	bool	append;
 }				t_pipex;
 
 /**
@@ -160,12 +161,12 @@ void	create_fork(t_pipex *pipex, t_ast *cmd);
  * 
  * @param file_name The redirection file name, use stdin and stdout for default
  * behaviour
- * @param read_or_write 0 for read 1 for write
+ * @param read_or_write 0 for read 1 for write 2 for append write
  * @param cmd The current command's ast
  * @param pipex The pipex struct initialized in exec_switch
  * @return int The file's fd
  */
-int		get_fd(char *file_name, bool read_or_write, t_ast *cmd, t_pipex *pipex);
+int		get_fd(char *file_name, int read_or_write, t_ast *cmd, t_pipex *pipex);
 /**
  * @brief This function is called just after ft_pipex_init and search through
  * the entire ast for redirection operaterators

--- a/Include/executing.h
+++ b/Include/executing.h
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:44:47 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/17 19:39:30 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 17:31:38 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ typedef struct s_pipex
 	char	*out_file;
 	int		(*pipe_fd)[2];
 	int		status;
-	int		temp;
+	int		nb_commands;
 	bool	append;
 }				t_pipex;
 

--- a/Include/minishell.h
+++ b/Include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tom <tom@student.42.fr>                    +#+  +:+       +#+        */
+/*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 16:19:25 by tom               #+#    #+#             */
-/*   Updated: 2024/10/10 18:27:58 by tom              ###   ########.fr       */
+/*   Updated: 2024/10/18 18:21:43 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,5 +24,7 @@
 # include <errno.h>
 # include <stdio.h>
 # include <signal.h>
+# include <readline/readline.h>
+# include <readline/history.h>
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CFLAGS =	-Wall -Wextra -Werror -g \
 			-IInclude 
 
 LFLAGS =	-Llibamoa \
-			-lamoa
+			-lamoa -lreadline
 
 BUILTINS = ft_cd ft_echo ft_env ft_exit ft_export ft_pwd ft_unset
 

--- a/src/builtins/ft_exit.c
+++ b/src/builtins/ft_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_exit.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tom <tom@student.42.fr>                    +#+  +:+       +#+        */
+/*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/10 14:02:11 by tom               #+#    #+#             */
-/*   Updated: 2024/10/14 22:05:56 by tom              ###   ########.fr       */
+/*   Updated: 2024/10/17 16:53:06 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,21 +14,27 @@
 
 void	free_ast(t_ast	*node)
 {
-	if (node->left)
-		free_ast(node->left);
-	if (node->right)
-		free_ast(node->right);
-	if (node->base)
+	if (node)
 	{
-		if (node->base->cmd)
-			ft_free_double_array(node->base->cmd);
-		if (node->base->file_name)
-			free(node->base->file_name);
-		if (node->base->path)
-			free(node->base->path);
-		free(node->base);
+		if (node->left)
+			free_ast(node->left);
+		if (node->right)
+			free_ast(node->right);
+		if (node->base)
+		{
+			if (node->base->cmd)
+				ft_free_double_array(node->base->cmd);
+			if (node->base->file_name)
+			{
+				free(node->base->file_name);
+				node->base->file_name = NULL;
+			}
+			if (node->base->path)
+				free(node->base->path);
+			free(node->base);
+		}
+		free(node);
 	}
-	free(node);
 }
 
 void	ft_exit(char	*line, t_ast	*ast, t_env	*env)

--- a/src/error_managent/error_management.c
+++ b/src/error_managent/error_management.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 21:21:04 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/16 19:17:22 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/17 16:41:07 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,27 +35,7 @@ void	error_free(t_ast *cmd, t_pipex *pipex)
 		free(pipex);
 		pipex = NULL;
 	}
-	if (cmd)
-	{
-		if (cmd->left)
-			error_free(cmd->left, pipex);
-		if (cmd->right)
-			error_free(cmd->right, pipex);
-		if (cmd->base)
-		{
-			if (cmd->base->cmd)
-				ft_free_double_array(cmd->base->cmd);
-			if (cmd->base->file_name)
-			{
-				free(cmd->base->file_name);
-				cmd->base->file_name = NULL;
-			}
-			if (cmd->base->path)
-				free(cmd->base->path);
-			free(cmd->base);
-		}
-		free(cmd);
-	}
+	free_ast(cmd);
 }
 
 static void	error_management_bis(int error_code, t_ast *cmd, t_pipex *pipex)

--- a/src/error_managent/error_management.c
+++ b/src/error_managent/error_management.c
@@ -6,32 +6,18 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 21:21:04 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 19:51:55 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 20:10:28 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-static void	free_pipe_list(t_pipex *pipex)
-{
-	int	i;
-
-	i = 0;
-	while (i < pipex->nb_commands - 1)
-	{
-		free(pipex->pipe_fd[i]);
-		i++;
-	}
-	free(pipex->pipe_fd);
-}
 
 void	error_free(t_ast *cmd, t_pipex *pipex)
 {
 	if (pipex)
 	{
 		if (pipex->pipe_fd)
-			free_pipe_list(pipex);
-			// free(pipex->pipe_fd);
+			free(pipex->pipe_fd);
 		free(pipex);
 		pipex = NULL;
 	}

--- a/src/error_managent/error_management.c
+++ b/src/error_managent/error_management.c
@@ -6,32 +6,32 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 21:21:04 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/17 16:41:07 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 19:51:55 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-// static void	free_pipe_list(t_pipex *pipex)
-// {
-// 	int	i;
+static void	free_pipe_list(t_pipex *pipex)
+{
+	int	i;
 
-// 	i = 0;
-// 	while (i < pipex->temp - 1)
-// 	{
-// 		free(pipex->pipe_fd[i]);
-// 		i++;
-// 	}
-// 	free(pipex->pipe_fd);
-// }
+	i = 0;
+	while (i < pipex->nb_commands - 1)
+	{
+		free(pipex->pipe_fd[i]);
+		i++;
+	}
+	free(pipex->pipe_fd);
+}
 
 void	error_free(t_ast *cmd, t_pipex *pipex)
 {
 	if (pipex)
 	{
 		if (pipex->pipe_fd)
-			// free_pipe_list(pipex);
-			free(pipex->pipe_fd);
+			free_pipe_list(pipex);
+			// free(pipex->pipe_fd);
 		free(pipex);
 		pipex = NULL;
 	}

--- a/src/executing/exec_heredocs.c
+++ b/src/executing/exec_heredocs.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/16 16:49:21 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/17 19:48:16 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 18:29:09 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,14 +21,15 @@ void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 	heredoc_fd = open("/tmp/heredoc_tmp", O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	if (heredoc_fd < 0)
 		error_management(e_file_name, cmd, pipex);
+	ft_putnbr_fd(heredoc_fd, heredoc_fd);
 	while (true)
 	{
-		ft_putstr_fd("heredoc> ", STDOUT_FILENO);
-		line = get_next_line(STDOUT_FILENO);
+		// readline("heredoc> ");
+		get_next_line(STDIN_FILENO);
 		if (ft_strcmp(line, cmd->right->right->base->file_name) == 0)
 		{
 			free(line);
-			break;
+			break ;
 		}
 		ft_putstr_fd(line, heredoc_fd);
 		ft_putstr_fd("\n", heredoc_fd);

--- a/src/executing/exec_heredocs.c
+++ b/src/executing/exec_heredocs.c
@@ -6,11 +6,19 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/16 16:49:21 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/21 21:07:32 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/22 19:02:58 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static void	heredoc_end(int heredoc_fd, t_pipex *pipex)
+{
+	close(heredoc_fd);
+	pipex->in_fd = open("heredoc_tmp", O_RDONLY);
+	if (pipex->in_fd == -1)
+		error_management(e_file_name, cmd, pipex);
+}
 
 void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 {
@@ -23,6 +31,12 @@ void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 	while (true)
 	{
 		line = readline("heredoc> ");
+		if (line == NULL)
+		{
+			ft_putstr_fd("Heredoc received SIGINT during prompt\n",
+				STDERR_FILENO);
+			break ;
+		}
 		if (ft_strcmp(line, cmd->right->right->base->file_name) == 0)
 		{
 			free(line);
@@ -32,8 +46,5 @@ void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 		ft_putstr_fd("\n", heredoc_fd);
 		free(line);
 	}
-	close(heredoc_fd);
-	pipex->in_fd = open("heredoc_fd", O_RDONLY);
-	if (heredoc_fd == -1)
-		error_management(e_file_name, cmd, pipex);
+	heredoc_end(heredoc_fd, pipex);
 }

--- a/src/executing/exec_heredocs.c
+++ b/src/executing/exec_heredocs.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/16 16:49:21 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/21 18:53:13 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 21:07:32 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,5 +32,8 @@ void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 		ft_putstr_fd("\n", heredoc_fd);
 		free(line);
 	}
-	pipex->in_fd = heredoc_fd;
+	close(heredoc_fd);
+	pipex->in_fd = open("heredoc_fd", O_RDONLY);
+	if (heredoc_fd == -1)
+		error_management(e_file_name, cmd, pipex);
 }

--- a/src/executing/exec_heredocs.c
+++ b/src/executing/exec_heredocs.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/16 16:49:21 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 18:29:09 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 18:53:13 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,15 +17,12 @@ void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 	int		heredoc_fd;
 	char	*line;
 
-	line = get_next_line(STDIN_FILENO);
-	heredoc_fd = open("/tmp/heredoc_tmp", O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	if (heredoc_fd < 0)
+	heredoc_fd = open("heredoc_tmp", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (heredoc_fd == -1)
 		error_management(e_file_name, cmd, pipex);
-	ft_putnbr_fd(heredoc_fd, heredoc_fd);
 	while (true)
 	{
-		// readline("heredoc> ");
-		get_next_line(STDIN_FILENO);
+		line = readline("heredoc> ");
 		if (ft_strcmp(line, cmd->right->right->base->file_name) == 0)
 		{
 			free(line);
@@ -35,5 +32,5 @@ void	handle_heredocs(t_ast *cmd, t_pipex *pipex)
 		ft_putstr_fd("\n", heredoc_fd);
 		free(line);
 	}
-	close(heredoc_fd);
+	pipex->in_fd = heredoc_fd;
 }

--- a/src/executing/exec_init.c
+++ b/src/executing/exec_init.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/01 12:03:46 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 17:30:39 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 19:57:04 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,9 @@ void	ft_pipex_init(t_ast *cmd, t_pipex *pipex, t_env *env)
 	pipex->pipe_i = 0;
 	pipex->in_file = "/dev/stdin";
 	pipex->out_file = "/dev/stdout";
+	pipex->in_fd = -1;
+	pipex->out_fd = -1;
 	pipex->nb_commands = env->nb_commands;
-	pipex->append = 0;
 	pipex->pipe_fd = malloc((env->nb_commands - 1) * sizeof(int [2]));
 	if (!pipex->pipe_fd)
 		error_management(e_malloc_failure, cmd, pipex);
@@ -33,6 +34,36 @@ void	ft_pipex_init(t_ast *cmd, t_pipex *pipex, t_env *env)
 	}
 }
 
+static int	check_redirect_type(t_ast *ast)
+{
+	return (ast->right->base->cmd_op == e_redirect_input || ast->right->base
+		->cmd_op == e_redirect_output || ast->right->base
+		->cmd_op == e_redirect_output_write_mod);
+}
+
+void	redirect_input_file(t_ast *ast, t_pipex *pipex)
+{
+	if (pipex->in_fd != -1)
+		close(pipex->in_fd);
+	pipex->in_file = ast->right->base->file_name;
+	pipex->in_fd = get_fd(pipex->in_file, 0, ast, pipex);
+	if (ast->right->right)
+		search_redirects(ast->right->right, pipex);
+}
+
+void	redirect_output_file(t_ast *ast, t_pipex *pipex)
+{
+	if (pipex->out_fd != -1)
+		close(pipex->out_fd);
+	pipex->out_file = ast->right->base->file_name;
+	if (ast->base->cmd_op == e_redirect_output)
+		pipex->out_fd = get_fd(pipex->out_file, 1, ast, pipex);
+	if (ast->base->cmd_op == e_redirect_output_write_mod)
+		pipex->out_fd = get_fd(pipex->out_file, 2, ast, pipex);
+	if (ast->right->right)
+		search_redirects(ast->right->right, pipex);
+}
+
 void	search_redirects(t_ast *ast, t_pipex *pipex)
 {
 	if (ast->right)
@@ -40,22 +71,14 @@ void	search_redirects(t_ast *ast, t_pipex *pipex)
 		if (ast->right->base->cmd_op == e_here_doc && ast->right->right->base
 			->file_name)
 			handle_heredocs(ast, pipex);
-		if (ast->right->base->cmd_op == e_redirect_input || ast->right->base
-			->cmd_op == e_redirect_output || ast->right->base
-			->cmd_op == e_redirect_output_write_mod)
+		if (check_redirect_type(ast))
 			search_redirects(ast->right, pipex);
 		if (ast->base->cmd_op == e_redirect_input
 			&& ast->right->base->file_name)
-			pipex->in_file = ast->right->base->file_name;
-		if (ast->base->cmd_op == e_redirect_output && ast->right->base
-			->file_name)
-			pipex->out_file = ast->right->base->file_name;
-		if (ast->base->cmd_op == e_redirect_output_write_mod
-			&& ast->right->base->file_name)
-		{
-			pipex->out_file = ast->right->base->file_name;
-			pipex->append = 1;
-		}
+			redirect_input_file(ast, pipex);
+		if ((ast->base->cmd_op == e_redirect_output || ast->base->cmd_op
+				== e_redirect_output_write_mod) && ast->right->base->file_name)
+			redirect_output_file(ast, pipex);
 	}
 }
 

--- a/src/executing/exec_init.c
+++ b/src/executing/exec_init.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/01 12:03:46 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 19:57:04 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 16:09:11 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,6 @@ void	ft_pipex_init(t_ast *cmd, t_pipex *pipex, t_env *env)
 
 	i = 0;
 	pipex->pipe_i = 0;
-	pipex->in_file = "/dev/stdin";
-	pipex->out_file = "/dev/stdout";
 	pipex->in_fd = -1;
 	pipex->out_fd = -1;
 	pipex->nb_commands = env->nb_commands;
@@ -45,8 +43,7 @@ void	redirect_input_file(t_ast *ast, t_pipex *pipex)
 {
 	if (pipex->in_fd != -1)
 		close(pipex->in_fd);
-	pipex->in_file = ast->right->base->file_name;
-	pipex->in_fd = get_fd(pipex->in_file, 0, ast, pipex);
+	pipex->in_fd = get_fd(ast->right->base->file_name, 0, ast, pipex);
 	if (ast->right->right)
 		search_redirects(ast->right->right, pipex);
 }
@@ -55,11 +52,10 @@ void	redirect_output_file(t_ast *ast, t_pipex *pipex)
 {
 	if (pipex->out_fd != -1)
 		close(pipex->out_fd);
-	pipex->out_file = ast->right->base->file_name;
 	if (ast->base->cmd_op == e_redirect_output)
-		pipex->out_fd = get_fd(pipex->out_file, 1, ast, pipex);
+		pipex->out_fd = get_fd(ast->right->base->file_name, 1, ast, pipex);
 	if (ast->base->cmd_op == e_redirect_output_write_mod)
-		pipex->out_fd = get_fd(pipex->out_file, 2, ast, pipex);
+		pipex->out_fd = get_fd(ast->right->base->file_name, 2, ast, pipex);
 	if (ast->right->right)
 		search_redirects(ast->right->right, pipex);
 }

--- a/src/executing/exec_init.c
+++ b/src/executing/exec_init.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/01 12:03:46 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/17 19:39:41 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 17:30:39 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ void	ft_pipex_init(t_ast *cmd, t_pipex *pipex, t_env *env)
 	pipex->pipe_i = 0;
 	pipex->in_file = "/dev/stdin";
 	pipex->out_file = "/dev/stdout";
-	pipex->temp = env->nb_commands;
+	pipex->nb_commands = env->nb_commands;
 	pipex->append = 0;
 	pipex->pipe_fd = malloc((env->nb_commands - 1) * sizeof(int [2]));
 	if (!pipex->pipe_fd)

--- a/src/executing/exec_init.c
+++ b/src/executing/exec_init.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/01 12:03:46 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/16 19:08:45 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/17 19:39:41 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ void	search_redirects(t_ast *ast, t_pipex *pipex)
 	{
 		if (ast->right->base->cmd_op == e_here_doc && ast->right->right->base
 			->file_name)
-			handle_heredocs(ast);
+			handle_heredocs(ast, pipex);
 		if (ast->right->base->cmd_op == e_redirect_input || ast->right->base
 			->cmd_op == e_redirect_output || ast->right->base
 			->cmd_op == e_redirect_output_write_mod)

--- a/src/executing/exec_pipes.c
+++ b/src/executing/exec_pipes.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/01 12:07:12 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/17 17:57:23 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 20:10:36 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,20 +55,15 @@ void	child_execution(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env)
 
 void	last_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env)
 {
-	int	fd_in;
-	int	fd_out;
-
 	search_redirects(cmd, pipex);
-	fd_in = get_fd(pipex->in_file, 0, cmd, pipex);
-	fd_out = get_fd(pipex->out_file, 1, cmd, pipex);
 	dup2(pipex->pipe_fd[curr_cmd - 1][0], STDIN_FILENO);
-	dup2(fd_in, STDIN_FILENO);
-	dup2(fd_out, STDOUT_FILENO);
+	dup2(pipex->in_fd, STDIN_FILENO);
+	dup2(pipex->out_fd, STDOUT_FILENO);
 	close_pipes(pipex, env);
-	if (fd_in != STDIN_FILENO)
-		close(fd_in);
-	if (fd_out != STDOUT_FILENO)
-		close(fd_out);
+	if (pipex->in_fd != -1)
+		close(pipex->in_fd);
+	if (pipex->out_fd != -1)
+		close(pipex->out_fd);
 	if (cmd->base->builtins)
 		exec_builtins(cmd, env);
 	else
@@ -83,21 +78,16 @@ void	last_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env)
 
 void	middle_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env)
 {
-	int	fd_in;
-	int	fd_out;
-
 	search_redirects(cmd, pipex);
-	fd_in = get_fd(pipex->in_file, 0, cmd, pipex);
-	fd_out = get_fd(pipex->out_file, 1, cmd, pipex);
 	dup2(pipex->pipe_fd[curr_cmd - 1][0], STDIN_FILENO);
 	dup2(pipex->pipe_fd[curr_cmd][1], STDOUT_FILENO);
-	dup2(fd_in, STDIN_FILENO);
-	dup2(fd_out, STDOUT_FILENO);
+	dup2(pipex->in_fd, STDIN_FILENO);
+	dup2(pipex->out_fd, STDOUT_FILENO);
 	close_pipes(pipex, env);
-	if (fd_in != STDIN_FILENO)
-		close(fd_in);
-	if (fd_out != STDOUT_FILENO)
-		close(fd_out);
+	if (pipex->in_fd != -1)
+		close(pipex->in_fd);
+	if (pipex->out_fd != -1)
+		close(pipex->out_fd);
 	if (cmd->base->builtins)
 		exec_builtins(cmd, env);
 	else
@@ -112,20 +102,15 @@ void	middle_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env)
 
 void	first_exec(int curr_cmd, t_ast *cmd, t_pipex *pipex, t_env *env)
 {
-	int	fd_in;
-	int	fd_out;
-
 	search_redirects(cmd, pipex);
-	fd_in = get_fd(pipex->in_file, 0, cmd, pipex);
-	fd_out = get_fd(pipex->out_file, 1, cmd, pipex);
 	dup2(pipex->pipe_fd[curr_cmd][1], STDOUT_FILENO);
 	close_pipes(pipex, env);
-	dup2(fd_in, STDIN_FILENO);
-	dup2(fd_out, STDOUT_FILENO);
-	if (fd_in != STDIN_FILENO)
-		close(fd_in);
-	if (fd_out != STDOUT_FILENO)
-		close(fd_out);
+	dup2(pipex->in_fd, STDIN_FILENO);
+	dup2(pipex->out_fd, STDOUT_FILENO);
+	if (pipex->in_fd != -1)
+		close(pipex->in_fd);
+	if (pipex->out_fd != -1)
+		close(pipex->out_fd);
 	if (cmd->base->builtins)
 		exec_builtins(cmd, env);
 	else

--- a/src/executing/exec_pipes.c
+++ b/src/executing/exec_pipes.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/01 12:07:12 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/16 15:38:51 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/17 17:57:23 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,6 @@ void	exec_handle_pipe(t_ast *cmd, t_pipex *pipex, t_env *env)
 	{
 		pipex->pipe_i++;
 		child_execution(env->nb_commands - pipex->pipe_i, cmd, pipex, env);
-		free(cmd->base->path);
 	}
 }
 

--- a/src/executing/exec_simple.c
+++ b/src/executing/exec_simple.c
@@ -59,8 +59,8 @@ void	exec_simple(t_ast *cmd, t_pipex *pipex, t_env *env)
 	if (cmd->base->pid == 0)
 	{
 		search_redirects(cmd, pipex);
-		if ((ft_strcmp(pipex->in_file, "/dev/stdin") != 0 || ft_strcmp(
-					pipex->out_file, "/dev/stdout")) && cmd->base->pid == 0)
+		if (ft_strcmp(pipex->in_file, "/dev/stdin") != 0 || ft_strcmp(
+					pipex->out_file, "/dev/stdout"))
 			exec_simple_redirect(cmd, pipex, env);
 		else
 			exec_only_child(cmd, pipex, env);

--- a/src/executing/exec_simple.c
+++ b/src/executing/exec_simple.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:16:54 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/14 15:19:17 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 19:36:10 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,28 +53,26 @@ void	exec_simple(t_ast *cmd, t_pipex *pipex, t_env *env)
 {
 	int		status;
 
-	search_redirects(cmd, pipex);
 	if (!(cmd->base->cmd_op == e_cd || cmd->base->cmd_op == e_export
-		|| cmd->base->cmd_op == e_unset))
+			|| cmd->base->cmd_op == e_unset))
 		create_fork(pipex, cmd);
-	if ((ft_strcmp(pipex->in_file, "/dev/stdin") != 0 || ft_strcmp(
-		pipex->out_file, "/dev/stdout")) && cmd->base->pid == 0)
-		exec_simple_redirect(cmd, pipex, env);
 	if (cmd->base->pid == 0)
-		exec_only_child(cmd, pipex, env);
+	{
+		search_redirects(cmd, pipex);
+		if ((ft_strcmp(pipex->in_file, "/dev/stdin") != 0 || ft_strcmp(
+					pipex->out_file, "/dev/stdout")) && cmd->base->pid == 0)
+			exec_simple_redirect(cmd, pipex, env);
+		else
+			exec_only_child(cmd, pipex, env);
+	}
 	waitpid(cmd->base->pid, &status, 0);
 }
 
 void	exec_simple_redirect(t_ast *cmd, t_pipex *pipex, t_env *env)
 {
-	int	fd_out;
-	int	fd_in;
-
-	fd_in = get_fd(pipex->in_file, 0, cmd, pipex);
-	fd_out = get_fd(pipex->out_file, 1, cmd, pipex);
-	dup2(fd_in, STDIN_FILENO);
-	dup2(fd_out, STDOUT_FILENO);
-	close(fd_in);
-	close(fd_out);
+	dup2(pipex->in_fd, STDIN_FILENO);
+	dup2(pipex->out_fd, STDOUT_FILENO);
+	close(pipex->in_fd);
+	close(pipex->out_fd);
 	exec_only_child(cmd, pipex, env);
 }

--- a/src/executing/exec_simple.c
+++ b/src/executing/exec_simple.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:16:54 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/21 20:15:35 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 20:20:26 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,6 @@ void	exec_simple_redirect(t_ast *cmd, t_pipex *pipex, t_env *env)
 {
 	dup2(pipex->in_fd, STDIN_FILENO);
 	dup2(pipex->out_fd, STDOUT_FILENO);
-	ft_putnbr_fd(pipex->in_fd, STDERR_FILENO);
 	close(pipex->in_fd);
 	close(pipex->out_fd);
 	exec_only_child(cmd, pipex, env);

--- a/src/executing/exec_simple.c
+++ b/src/executing/exec_simple.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:16:54 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 19:36:10 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 20:15:35 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,8 +59,7 @@ void	exec_simple(t_ast *cmd, t_pipex *pipex, t_env *env)
 	if (cmd->base->pid == 0)
 	{
 		search_redirects(cmd, pipex);
-		if (ft_strcmp(pipex->in_file, "/dev/stdin") != 0 || ft_strcmp(
-					pipex->out_file, "/dev/stdout"))
+		if (pipex->in_fd != -1 || pipex->out_fd != -1)
 			exec_simple_redirect(cmd, pipex, env);
 		else
 			exec_only_child(cmd, pipex, env);
@@ -72,6 +71,7 @@ void	exec_simple_redirect(t_ast *cmd, t_pipex *pipex, t_env *env)
 {
 	dup2(pipex->in_fd, STDIN_FILENO);
 	dup2(pipex->out_fd, STDOUT_FILENO);
+	ft_putnbr_fd(pipex->in_fd, STDERR_FILENO);
 	close(pipex->in_fd);
 	close(pipex->out_fd);
 	exec_only_child(cmd, pipex, env);

--- a/src/executing/exec_utils.c
+++ b/src/executing/exec_utils.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:25:44 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/18 18:23:17 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 19:17:18 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,7 @@ void	create_fork(t_pipex *pipex, t_ast *cmd)
 		error_management(e_fork_failure, cmd, pipex);
 }
 
-int	get_fd(char *file_name, bool read_or_write, t_ast *cmd, t_pipex *pipex)
+int	get_fd(char *file_name, int read_or_write, t_ast *cmd, t_pipex *pipex)
 {
 	int	fd;
 
@@ -72,15 +72,12 @@ int	get_fd(char *file_name, bool read_or_write, t_ast *cmd, t_pipex *pipex)
 		return (STDIN_FILENO);
 	if (ft_strcmp(file_name, "/dev/stdout") == 0)
 		return (STDOUT_FILENO);
-	if (!read_or_write)
+	if (read_or_write == 0)
 		fd = open(file_name, O_RDONLY);
-	else
-	{
-		if (pipex->append)
-			fd = open(file_name, O_WRONLY | O_CREAT | O_APPEND, 0644);
-		else
-			fd = open(file_name, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	}
+	if (read_or_write == 1)
+		fd = open(file_name, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (read_or_write == 2)
+		fd = open(file_name, O_WRONLY | O_CREAT | O_APPEND, 0644);
 	if (fd == -1)
 		error_management(e_file, cmd, pipex);
 	return (fd);

--- a/src/executing/exec_utils.c
+++ b/src/executing/exec_utils.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:25:44 by bchedru           #+#    #+#             */
-/*   Updated: 2024/10/16 19:21:01 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/18 18:23:17 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 
 void	exec_builtins(t_ast *cmd, t_env *env)
 {
-	(void)env;
 	if (cmd->base->cmd_op >= e_echo)
 	{
 		if (cmd->base->cmd_op == e_echo)

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:09:02 by tom               #+#    #+#             */
-/*   Updated: 2024/10/21 19:09:08 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/22 17:43:33 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,6 +66,7 @@ bool	loop(t_env	*env)
 	line = readline("minicheh -> ");
 	if (line[0] == '\0')
 		return (false);
+	add_history(line);
 	ast = ft_calloc(1, sizeof(t_ast) + 1);
 	ast->base = ft_calloc(1, sizeof(t_ast_content) + 1);
 	env->nb_commands = 0;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:09:02 by tom               #+#    #+#             */
-/*   Updated: 2024/10/17 16:56:59 by bchedru          ###   ########.fr       */
+/*   Updated: 2024/10/21 19:09:08 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,9 +63,8 @@ bool	loop(t_env	*env)
 	t_ast	*ast;
 	char	**temp;
 
-	write(1, "minicheh -> ", 13);
-	line = get_next_line(0);
-	if (line[0] == '\n')
+	line = readline("minicheh -> ");
+	if (line[0] == '\0')
 		return (false);
 	ast = ft_calloc(1, sizeof(t_ast) + 1);
 	ast->base = ft_calloc(1, sizeof(t_ast_content) + 1);
@@ -84,9 +83,8 @@ bool	loop(t_env	*env)
 	return (true);
 }
 
-int main(int ac, char **av, char **envp)
+int	main(int ac, char **av, char **envp)
 {
-
 	t_env	*env;
 
 	(void)av;
@@ -104,7 +102,7 @@ int main(int ac, char **av, char **envp)
 		signal(SIGQUIT, SIG_IGN);
 		signal(SIGINT, &sigint_handler);
 		if (!loop(env))
-			continue;
+			continue ;
 	}
 	ft_free_double_array(env->envv);
 	free(env);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tom <tom@student.42.fr>                    +#+  +:+       +#+        */
+/*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:09:02 by tom               #+#    #+#             */
-/*   Updated: 2024/10/17 13:31:04 by tom              ###   ########.fr       */
+/*   Updated: 2024/10/17 16:56:59 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,6 @@ bool	loop(t_env	*env)
 	free(line);
 	line = NULL;
 	exec_switch(ast, env);
-	free_ast(ast);
 	ast = NULL;
 	temp = ft_calloc(3, sizeof(char *));
 	temp[0] = ft_strdup(env->pwd);
@@ -82,7 +81,6 @@ bool	loop(t_env	*env)
 	temp[2] = NULL;
 	ft_export(temp, &env);
 	ft_free_double_array(temp);
-	free(temp);
 	return (true);
 }
 

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tom <tom@student.42.fr>                    +#+  +:+       +#+        */
+/*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 19:12:58 by tom               #+#    #+#             */
-/*   Updated: 2024/10/17 13:32:18 by tom              ###   ########.fr       */
+/*   Updated: 2024/10/21 20:07:55 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,8 @@ void	add_env(t_env	**env_start, t_ast	**ast)
 	(*ast)->base->path = NULL;
 	if ((*ast)->base->cmd_op != e_file_name)
 		(*ast)->base->file_name = NULL;
-	if (!(((*ast)->base->cmd_op == e_external_control) || ((*ast)->base->cmd_op >= e_echo)))
+	if (!(((*ast)->base->cmd_op == e_external_control)
+			|| ((*ast)->base->cmd_op >= e_echo)))
 		(*ast)->base->cmd = NULL;
 	if ((*ast)->left)
 		add_env(env_start, &(*ast)->left);
@@ -70,7 +71,6 @@ void	parse(char *line, t_ast	**ast, t_env	*env_start)
 	(*ast)->left = NULL;
 	(*ast)->right = NULL;
 	(*ast)->t_env = &env_start;
-	line[ft_strlen(line) - 1] = '\0';
 	while (line[++i])
 	{
 		if (is_op(line[i]))

--- a/src/parse/redirect_handler.c
+++ b/src/parse/redirect_handler.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect_handler.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tom <tom@student.42.fr>                    +#+  +:+       +#+        */
+/*   By: bchedru <bchedru@student.42lehavre.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/28 18:33:43 by tom               #+#    #+#             */
-/*   Updated: 2024/10/11 14:12:18 by tom              ###   ########.fr       */
+/*   Updated: 2024/10/21 18:00:32 by bchedru          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,17 +23,8 @@ void	add_new_operator(t_ast	*node, char	*command, t_cmd_and_op op)
 	new_node->base->cmd_op = op;
 	new_node->base->is_op = true;
 	new_node->left = NULL;
-	if (op == e_here_doc)
-	{
-		if (command)
-			new_node->right->base->cmd = ft_split(command, ' ');
-	}
-	else if (op == e_redirect_input || op == e_redirect_output
-				|| op == e_redirect_output_write_mod)
-	{
-		new_node->right->base->file_name = ft_strdup(rem_wspace(command));
-		new_node->right->base->cmd_op = e_file_name;
-	}
+	new_node->right->base->file_name = ft_strdup(rem_wspace(command));
+	new_node->right->base->cmd_op = e_file_name;
 	node->right = new_node;
 }
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -16,3 +16,9 @@
    ...
    obj:/usr/bin/grep
 }
+{
+   ignore_clear_leaks
+   Memcheck:Leak
+   ...
+   obj:/usr/bin/clear
+}


### PR DESCRIPTION
This pull request includes several significant changes to the `minishell` project, mainly focusing on improving file handling, error management, and simplifying the code structure. The most important changes include modifications to the `t_pipex` struct, updates to file descriptor handling, and enhancements to the heredoc functionality.

### Struct and File Descriptor Handling:

* [`Include/executing.h`](diffhunk://#diff-fd365620c5fab6892f21ba1e7fc1f9aff80e025b101456a10e909f308aa7ba14L23-R27): Changed `t_pipex` struct to use file descriptors (`in_fd`, `out_fd`) instead of file names (`in_file`, `out_file`). Updated `get_fd` function to use an integer for `read_or_write` instead of a boolean. [[1]](diffhunk://#diff-fd365620c5fab6892f21ba1e7fc1f9aff80e025b101456a10e909f308aa7ba14L23-R27) [[2]](diffhunk://#diff-fd365620c5fab6892f21ba1e7fc1f9aff80e025b101456a10e909f308aa7ba14L163-R167)
* [`src/executing/exec_init.c`](diffhunk://#diff-898dd4a9098dece309b16e9b941d657ab3bd26f3a8a72125a4c260f9e7023798L21-R23): Updated `ft_pipex_init` to initialize `in_fd` and `out_fd` to -1. Added new functions `redirect_input_file` and `redirect_output_file` for handling redirections. [[1]](diffhunk://#diff-898dd4a9098dece309b16e9b941d657ab3bd26f3a8a72125a4c260f9e7023798L21-R23) [[2]](diffhunk://#diff-898dd4a9098dece309b16e9b941d657ab3bd26f3a8a72125a4c260f9e7023798R35-R77)

### Heredoc Functionality:

* [`src/executing/exec_heredocs.c`](diffhunk://#diff-a1f7ad4f2a2b21374e9de782c9cc77b37aa7059c3b19c69b9f233165492928eaL9-R49): Replaced the old heredoc handling logic with a new implementation using the `readline` library. Added `heredoc_end` function to manage heredoc file descriptors.

### Error Management:

* [`src/error_managent/error_management.c`](diffhunk://#diff-bbd10fc29939c5e4e26bdde1d6c1911068a4608e9ad318c543b4c8c68b3f2b82L9-R24): Simplified the `error_free` function by using the `free_ast` function to free the AST. Removed commented-out code.

### Code Simplification:

* [`src/executing/exec_pipes.c`](diffhunk://#diff-cf774c8161d2ea2dd830c170990c4197180d74d7914ae0bdffc1d10b661288d0L59-R66): Removed redundant file descriptor handling code in `first_exec`, `middle_exec`, and `last_exec` functions. [[1]](diffhunk://#diff-cf774c8161d2ea2dd830c170990c4197180d74d7914ae0bdffc1d10b661288d0L59-R66) [[2]](diffhunk://#diff-cf774c8161d2ea2dd830c170990c4197180d74d7914ae0bdffc1d10b661288d0L87-R90) [[3]](diffhunk://#diff-cf774c8161d2ea2dd830c170990c4197180d74d7914ae0bdffc1d10b661288d0L116-R113)
* [`src/executing/exec_simple.c`](diffhunk://#diff-e64632543d6d099da0e14905a063da29ca15a5d24f09964e1d769900d50d30f0L56-R75): Simplified `exec_simple` and `exec_simple_redirect` by using `in_fd` and `out_fd` directly.

### Miscellaneous:

* [`Include/minishell.h`](diffhunk://#diff-88db2e00f2bae89eaf6d947897309c56425aab275c88b48be4029f83f8737cc9R27-R28): Added `readline` and `history` includes.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L11-R11): Linked the `readline` library.

These changes collectively enhance the maintainability and functionality of the `minishell` project.